### PR TITLE
add instructions for running the mongo shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ After running the seed task you should be able to log in to the app with usernam
 
 ## View app
 - `localhost:8080/login`
+
+## Running the mongo shell
+- run `docker ps` and copy the `CONTAINER ID` associated with the docker container running mongo
+- run the shell in the docker container
+  ```
+  docker exec -it CONTAINER mongo
+  ```


### PR DESCRIPTION
Adds instructions for how to run the mongo shell in docker to the README.
I had to google how to do this last night so I figured I'd save myself and everyone else the trouble in the future 😖