### PR TITLE
Add State Error Handling

### DIFF
--- a/app/controllers/campaign.js
+++ b/app/controllers/campaign.js
@@ -95,16 +95,17 @@ const getLegislatorForCampaignFromOpenStates = function (data, title) {
 };
 
 campaignController.findLegislator = async function (address, latitude, longitude, campaignId, response) {
-    var success = function (representatives) {
+    var success = function (representatives, campaign) {
         var representativeFound = (representatives.length > 0);
         var responseObject = {
             representativeFound: representativeFound,
-            representativeInfo: representatives
+            representativeInfo: representatives,
+            campaign: campaign,
         };
         response.send(JSON.stringify(responseObject));
     };
 
-    let currentCampaign = await Campaign.findById(campaignId, 'legislature_level').catch(error => console.log(error));
+    let currentCampaign = await Campaign.findById(campaignId).catch(error => console.log(error));
     let legislatureLevels = Object.keys(currentCampaign.legislature_level).filter(lev => currentCampaign.legislature_level[lev]);
     let legislators = [];
 
@@ -131,7 +132,7 @@ campaignController.findLegislator = async function (address, latitude, longitude
         legislators.push(getLegislatorForCampaignFromOpenStates(legislator, 'State Assembly Member'));
     }
 
-    success(legislators);
+    success(legislators, currentCampaign);
 };
 
 module.exports = campaignController;

--- a/app/views/campaign.hbs
+++ b/app/views/campaign.hbs
@@ -68,5 +68,14 @@
       </div>
     </div>
 
+    <div id="rep-container" ng-show="stateMismatch" class="ng-hide">
+      <div class="text-center">
+        <p class="lead reversed-text">
+          We're sorry, the address you entered is in a state that is not included in this campaign.<br>
+          Thank you for your interest!
+        </p>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/app/views/campaign.hbs
+++ b/app/views/campaign.hbs
@@ -3,6 +3,15 @@
 
     <ng-map center="[40.74, -74.18]"></ng-map>
 
+    <div id="rep-container" ng-show="stateOutOfRange" class="ng-hide">
+      <div class="text-center">
+        <p class="lead reversed-text">
+          We're sorry, the address you entered is in a state not covered by our database. Please try entering an
+          address in the 50 US States or Puerto Rico.
+        </p>
+      </div>
+    </div>
+
     <div class="campaign-circles" ng-show="addrForm" class="ng-hide">
       <h3 class="reversed-text">Enter the address where you vote to find the correct representative.</h3>
       <br>

--- a/public/js/campaign/visitor.controller.js
+++ b/public/js/campaign/visitor.controller.js
@@ -19,13 +19,19 @@ export default angular.module('helloGov')
             let address = $scope.locDetails.formatted_address.replace(/ /g, '%20');
             let latitude = $scope.locDetails.geometry.location.lat();
             let longitude = $scope.locDetails.geometry.location.lng();
+            let userState = $scope.locDetails.adr_address.split("region")[1].split("").splice(2, 2).join("");
 
             $http.get('/locateLegislator', { params: { address: address, latitude: latitude, longitude: longitude, campaignId: $scope.campaign } })
                 .then(function (result) {
                     $scope.repFound = result.data.representativeFound;
                     $scope.repInfo = result.data.representativeInfo;
                     $scope.addrForm = false;
-                    if ($scope.repFound) {
+                    let legislatureLevel = result.data.campaign.legislature_level;
+
+                    if ((legislatureLevel.state_senate || legislatureLevel.state_assembly) && (userState !== result.data.campaign.state)) {
+                        $scope.stateMismatch = true;
+                    }
+                    else if ($scope.repFound) {
                         $scope.repForm = true;
                     } else {
                         $scope.repNotFoundForm = true;
@@ -39,5 +45,6 @@ export default angular.module('helloGov')
         $scope.addrForm = true;
         $scope.repForm = false;
         $scope.repNotFoundForm = false;
+        $scope.stateMismatch = false;
     })
     .name;

--- a/public/js/create/createPage.component.js
+++ b/public/js/create/createPage.component.js
@@ -11,7 +11,6 @@ export default angular.module('helloGov')
             $scope.federalHouseSelected = false;
             $scope.stateSenateSelected = false;
             $scope.stateAssemblySelected = false;
-            $scope.stateNames = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'District of Columbia', 'Federated States of Micronesia', 'Florida', 'Georgia', 'Guam', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Marshall Islands', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Northern Mariana Islands', 'Ohio', 'Oklahoma', 'Oregon', 'Palau', 'Pennsylvania', 'Puerto Rico', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virgin Island', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
 
             // FIXME: this is super brittle to get the campaignId like this, but we're not using angular's
             // routing so it's not possible to get it using angular yet
@@ -42,17 +41,17 @@ export default angular.module('helloGov')
             $scope.updateLegislatureSelection = function () {
                 const checked = event.target.checked;
                 switch (event.target.name) {
-                case 'federal-senate':
-                    $scope.federalSenateSelected = checked;
-                    return;
-                case 'federal-house':
-                    $scope.federalHouseSelected = checked;
-                    return;
-                case 'state-senate':
-                    $scope.stateSenateSelected = checked;
-                    return;
-                case 'state-assembly':
-                    $scope.stateAssemblySelected = checked;
+                    case 'federal-senate':
+                        $scope.federalSenateSelected = checked;
+                        return;
+                    case 'federal-house':
+                        $scope.federalHouseSelected = checked;
+                        return;
+                    case 'state-senate':
+                        $scope.stateSenateSelected = checked;
+                        return;
+                    case 'state-assembly':
+                        $scope.stateAssemblySelected = checked;
                 }
             };
 

--- a/public/js/create/createPage.html
+++ b/public/js/create/createPage.html
@@ -106,6 +106,7 @@
           <option value="OK">Oklahoma</option>
           <option value="OR">Oregon</option>
           <option value="PA">Pennsylvania</option>
+          <option value="PR">Puerto Rico</option>
           <option value="RI">Rhode Island</option>
           <option value="SC">South Carolina</option>
           <option value="SD">South Dakota</option>

--- a/public/js/create/createPage.html
+++ b/public/js/create/createPage.html
@@ -65,9 +65,59 @@
         <br />
         <select name="state-select" class="state-select form-control input-lg campaign-input" ng-class="{'form-field-error': createForm.state-select.$touched && createForm.state-select.$invalid}"
           ng-show="stateLegislatureSelected() || $ctrl.campaign.legislature_level.state_senate || $ctrl.campaign.legislature_level.state_assembly"
-          ng-model="$ctrl.campaign.state" ng-options="state as state for state in stateNames track by state"
-          ng-required="stateLegislatureSelected()" ng-disabled="federalLegislatureSelected()">
+          ng-model="$ctrl.campaign.state" ng-required="stateLegislatureSelected()" ng-disabled="federalLegislatureSelected()">
           <option value="" selected disabled>Select State</option>
+          <option value="AL">Alabama</option>
+          <option value="AK">Alaska</option>
+          <option value="AZ">Arizona</option>
+          <option value="AR">Arkansas</option>
+          <option value="CA">California</option>
+          <option value="CO">Colorado</option>
+          <option value="CT">Connecticut</option>
+          <option value="DE">Delaware</option>
+          <option value="DC">District Of Columbia</option>
+          <option value="FL">Florida</option>
+          <option value="GA">Georgia</option>
+          <option value="HI">Hawaii</option>
+          <option value="ID">Idaho</option>
+          <option value="IL">Illinois</option>
+          <option value="IN">Indiana</option>
+          <option value="IA">Iowa</option>
+          <option value="KS">Kansas</option>
+          <option value="KY">Kentucky</option>
+          <option value="LA">Louisiana</option>
+          <option value="ME">Maine</option>
+          <option value="MD">Maryland</option>
+          <option value="MA">Massachusetts</option>
+          <option value="MI">Michigan</option>
+          <option value="MN">Minnesota</option>
+          <option value="MS">Mississippi</option>
+          <option value="MO">Missouri</option>
+          <option value="MT">Montana</option>
+          <option value="NE">Nebraska</option>
+          <option value="NV">Nevada</option>
+          <option value="NH">New Hampshire</option>
+          <option value="NJ">New Jersey</option>
+          <option value="NM">New Mexico</option>
+          <option value="NY">New York</option>
+          <option value="NC">North Carolina</option>
+          <option value="ND">North Dakota</option>
+          <option value="OH">Ohio</option>
+          <option value="OK">Oklahoma</option>
+          <option value="OR">Oregon</option>
+          <option value="PA">Pennsylvania</option>
+          <option value="RI">Rhode Island</option>
+          <option value="SC">South Carolina</option>
+          <option value="SD">South Dakota</option>
+          <option value="TN">Tennessee</option>
+          <option value="TX">Texas</option>
+          <option value="UT">Utah</option>
+          <option value="VT">Vermont</option>
+          <option value="VA">Virginia</option>
+          <option value="WA">Washington</option>
+          <option value="WV">West Virginia</option>
+          <option value="WI">Wisconsin</option>
+          <option value="WY">Wyoming</option>
         </select>
       </div>
 


### PR DESCRIPTION
Added feature to respond with meaningful messages when the user enters an invalid state:
- If the user enters an invalid state for a state-level campaign, they will be notified that their state isn't relevant to the campaign.
- If the user enters a state outside of the US 50 & PR for any campaign, they will be prompted to do so.

Also added Puerto Rico to the state selection.