### PR TITLE
[#151] Add basic analytics to Campaign list page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2895,8 +2895,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2914,13 +2913,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2933,18 +2930,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3047,8 +3041,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3058,7 +3051,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3071,20 +3063,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3101,7 +3090,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3174,8 +3162,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3185,7 +3172,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3261,8 +3247,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3292,7 +3277,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3310,7 +3294,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3349,13 +3332,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -3477,7 +3458,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -4061,8 +4041,7 @@
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "optional": true
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -4084,7 +4063,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2895,7 +2895,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2913,11 +2914,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2930,15 +2933,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3041,7 +3047,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3051,6 +3058,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3063,17 +3071,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3090,6 +3101,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3162,7 +3174,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3172,6 +3185,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3247,7 +3261,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3277,6 +3292,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3294,6 +3310,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3332,11 +3349,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -3458,6 +3477,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -4041,7 +4061,8 @@
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -4063,6 +4084,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }

--- a/public/js/home/campaigns-list.component.js
+++ b/public/js/home/campaigns-list.component.js
@@ -3,7 +3,7 @@ import angular from 'angular';
 export default angular.module('helloGov')
     .component('campaignsList', {
         template: require('./campaigns-list.html'),
-        controller: function ($location, $http, constants) {
+        controller: function ($scope, $location, $http, constants) {
             'ngInject';
             let self = this;
 
@@ -15,6 +15,13 @@ export default angular.module('helloGov')
                 $http.get(`${constants.API_ROOT}/campaigns?sort=-createdAt`)
                     .then(function (result) {
                         self.campaigns = result.data;
+                        $http.get(`${constants.API_ROOT}/events?campaignId=${$scope.campaignId}`, $scope.analytics)
+                        .then(function(result) {
+                            $scope.analytics = result.data;
+                        })
+                        .catch(function(data) {
+                            console.log(`Error:  ${JSON.stringify(data)}`);
+                        });
                     })
                     .catch(function (data) {
                         self.error = 'There was an error getting your campaigns. Please try agan later.';

--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -7,25 +7,38 @@
             <h4>{[{campaign.title}]}</h4>
             <h5 ng-if="!campaign.publish">DRAFT</h5>
             <div class="text-center">
-                <!-- TODO: Update analytics link when we have individual pages for each campaign -->
-                <a href="{[{campaign.url}]}/analytics"><div class="option-button">
-                    <input type="image" src="/images/analytics_icon.svg" />
-                    <p>Analytics</p>
-                </div></a>
-                <!-- TODO: This should give feedback, ideally like in the mockup -->
-                <div class="option-button">
-                    <input type="image" src="/images/white_link_icon.jpg" ngclipboard data-clipboard-text="{[{$ctrl.hostName}]}{[{campaign.url}]}" />
-                    <p>Link</p>
+                <div>
+                    <!-- TODO: Update analytics link when we have individual pages for each campaign -->
+                    <!-- Removed because not enough analytics to dedicate to entire page -->
+                    <!-- <a href="{[{campaign.url}]}/analytics"><div class="option-button">
+                        <input type="image" src="/images/analytics_icon.svg" />
+                        <p>Analytics</p>
+                    </div></a> -->
+                    <!-- TODO: This should give feedback, ideally like in the mockup -->
+                    <div class="option-button">
+                        <input type="image" src="/images/white_link_icon.jpg" ngclipboard data-clipboard-text="{[{$ctrl.hostName}]}{[{campaign.url}]}" />
+                        <p>Link</p>
+                    </div>
+                    <a ng-href="{[{campaign.url}]}/edit"><div class="option-button">
+                        <input type="image" src="/images/pencil.jpg" />
+                        <p>Edit</p>
+                    </div></a>
+                    <!-- TODO: Show a warning first like in the mockup -->
+                    <a ng-click="$ctrl.delete(campaign.id)"><div class="option-button">
+                        <input type="image" src="/images/white_delete_icon.jpg" />
+                        <p>Delete</p>
+                    </div></a>
+                    <div>
+                        <div class="option-button">
+                            <p class="analytics-display">{[{analytics.call}]}</p>
+                            <p>Calls</p>
+                        </div>
+                        <div class="option-button">
+                            <p class="analytics-display">{[{analytics.visit}]}</p>
+                            <p>Visits</p>
+                        </div>
+                    </div>
                 </div>
-                <a ng-href="{[{campaign.url}]}/edit"><div class="option-button">
-                    <input type="image" src="/images/pencil.jpg" />
-                    <p>Edit</p>
-                </div></a>
-                <!-- TODO: Show a warning first like in the mockup -->
-                <a ng-click="$ctrl.delete(campaign.id)"><div class="option-button">
-                    <input type="image" src="/images/white_delete_icon.jpg" />
-                    <p>Delete</p>
-                </div></a>
             </div>
         </div>
     </div>

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -7,6 +7,10 @@
     text-transform: uppercase;
     font-weight: bold;
 
+    .analytics-display {
+        font-size: 1.2em;
+    }
+
     .campaign-date {
         display: inline-block;
         border-bottom: 1px solid $blue-light;


### PR DESCRIPTION
#151 
Made *calls* and *visits* display on campaign list rather than have dedicated analytics page because there are currently very few analytics. 

### Before edits
<img width="343" alt="before" src="https://user-images.githubusercontent.com/15844781/53780968-a1733800-3ebb-11e9-9d50-7fe91aac4a5b.png">

### After edits 
<img width="335" alt="after" src="https://user-images.githubusercontent.com/15844781/53780985-b64fcb80-3ebb-11e9-8154-cd74bb073e74.png">

*Did not change the following functionality*: Links direct to corresponding campaign page (i.e. edit goes to editing the campaign and delete will delete the selected campaign).

Added the *views* and *calls* to display the views and calls for the campaign

