### PR TITLE
tab indexes for create/edit campaign fields (issue #227)

### DIFF
--- a/public/js/create/createPage.html
+++ b/public/js/create/createPage.html
@@ -19,7 +19,8 @@
           <h4>CAMPAIGN TITLE</h4>
         </div>
         <textarea name="title" class="form-control input-lg campaign-input" ng-class="{'form-field-error': createForm.title.$touched && createForm.title.$invalid}"
-          ng-model="$ctrl.campaign.title" rows="2" maxlength="140"   placeholder="Ex: 'Vote YES on SB280.'"required>
+          ng-model="$ctrl.campaign.title" rows="2" maxlength="140" placeholder="Ex: 'Vote YES on SB280.'"required
+          tabindex="1">
         </textarea>
         <div class="max-text">Max 140 characters</div>
       </div>
@@ -33,7 +34,8 @@
             <td>
               <input type="checkbox" ng-model="$ctrl.campaign.legislature_level.federal_senate" ng-change="updateLegislatureSelection()"
                 ng-value="true" ng-disabled="stateLegislatureSelected() || $ctrl.campaign.legislature_level.state_senate || $ctrl.campaign.legislature_level.state_assembly"
-                name="federal-senate" ng-required="!stateLegislatureSelected() && !federalHouseSelected" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}">
+                name="federal-senate" ng-required="!stateLegislatureSelected() && !federalHouseSelected" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}"
+                tabindex="2">
             </td>
             <td class="legislature-level-title">Federal: Senate</td>
           </tr>
@@ -41,7 +43,8 @@
             <td>
               <input type="checkbox" ng-model="$ctrl.campaign.legislature_level.federal_house" ng-change="updateLegislatureSelection()"
                 ng-value="true" ng-disabled="stateLegislatureSelected() || $ctrl.campaign.legislature_level.state_senate || $ctrl.campaign.legislature_level.state_assembly"
-                name="federal-house" ng-required="!stateLegislatureSelected() && !federalSenateSelected" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}">
+                name="federal-house" ng-required="!stateLegislatureSelected() && !federalSenateSelected" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}"
+                tabindex="3">
             </td>
             <td class="legislature-level-title">Federal: House</td>
           </tr>
@@ -49,7 +52,8 @@
             <td>
               <input type="checkbox" ng-model="$ctrl.campaign.legislature_level.state_senate" ng-change="updateLegislatureSelection()"
                 ng-value="true" ng-disabled="federalLegislatureSelected() || $ctrl.campaign.legislature_level.federal_senate || $ctrl.campaign.legislature_level.federal_house"
-                name="state-senate" ng-required="!federalLegislatureSelected() && !stateAssemblySelected" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}">
+                name="state-senate" ng-required="!federalLegislatureSelected() && !stateAssemblySelected" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}"
+                tabindex="4">
             </td>
             <td class="legislature-level-title">State: Senate</td>
           </tr>
@@ -57,7 +61,8 @@
             <td>
               <input type="checkbox" ng-model="$ctrl.campaign.legislature_level.state_assembly" ng-change="updateLegislatureSelection()"
                 ng-value="true" ng-disabled="federalLegislatureSelected() || $ctrl.campaign.legislature_level.federal_senate || $ctrl.campaign.legislature_level.federal_house"
-                name="state-assembly" ng-required="!federalLegislatureSelected() && !stateSenateSelected" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}">
+                name="state-assembly" ng-required="!federalLegislatureSelected() && !stateSenateSelected" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}"
+                tabindex="5">
             </td>
             <td class="legislature-level-title">State: Assembly</td>
           </tr>
@@ -65,7 +70,8 @@
         <br />
         <select name="state-select" class="state-select form-control input-lg campaign-input" ng-class="{'form-field-error': createForm.state-select.$touched && createForm.state-select.$invalid}"
           ng-show="stateLegislatureSelected() || $ctrl.campaign.legislature_level.state_senate || $ctrl.campaign.legislature_level.state_assembly"
-          ng-model="$ctrl.campaign.state" ng-required="stateLegislatureSelected()" ng-disabled="federalLegislatureSelected()">
+          ng-model="$ctrl.campaign.state" ng-required="stateLegislatureSelected()" ng-disabled="federalLegislatureSelected()"
+          tabindex="6">
           <option value="" selected disabled>Select State</option>
           <option value="AL">Alabama</option>
           <option value="AK">Alaska</option>
@@ -127,7 +133,7 @@
           <h4>SCRIPT</h4>
         </div>
         <textarea name="script" class="form-control input-lg campaign-input" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}"
-          ng-model="$ctrl.campaign.script" rows="6" maxlength="1000" required>
+          ng-model="$ctrl.campaign.script" rows="6" maxlength="1000" required tabindex="7">
         </textarea>
         <div class="max-text">Max 1000 characters</div>
       </div>
@@ -137,7 +143,8 @@
           <h4>THANK YOU MESSAGE</h4>
         </div>
         <textarea name="thank_you" class="form-control input-lg campaign-input" ng-class="{'form-field-error': createForm.thank_you.$touched && createForm.thank_you.$invalid}"
-          ng-model="$ctrl.campaign.thank_you" rows="4" maxlength="250"  placeholder="Appears after a call is made." required>
+          ng-model="$ctrl.campaign.thank_you" rows="4" maxlength="250"  placeholder="Appears after a call is made." required
+          tabindex="8">
         </textarea>
         <div class="max-text">Max 250 characters</div>
       </div>
@@ -147,7 +154,7 @@
           <h4>LEARN MORE URL</h4>
         </div>
         <textarea name="learn_more" class="form-control input-lg campaign-input" ng-model="$ctrl.campaign.learn_more"
-          rows="2" maxlength="200" placeholder="Link to a page on your org's website about the issue.">
+          rows="2" maxlength="200" placeholder="Link to a page on your org's website about the issue." tabindex="9">
         </textarea>
         <div class="max-text">Max 200 characters</div>
       </div>
@@ -156,15 +163,17 @@
         {[{error}]}
       </div>
       <div class="form-group align-right">
-        <button type="button" class="btn secondary-button btn-lg" ng-click="$ctrl.saveCampaign(false)" ng-disabled="!createForm.$valid">
+        <button type="button" class="btn secondary-button btn-lg" ng-click="$ctrl.saveCampaign(false)" ng-disabled="!createForm.$valid"
+            tabindex="10">
           Save As Draft
         </button>
-        <button type="submit" class="btn primary-button btn-lg" ng-click="$ctrl.saveCampaign(true)" ng-disabled="!createForm.$valid">
+        <button type="submit" class="btn primary-button btn-lg" ng-click="$ctrl.saveCampaign(true)" ng-disabled="!createForm.$valid"
+            tabindex="11">
           Submit
         </button>
       </div>
       <div class="form-group align-right">
-        <a href="/home">Cancel</a>
+        <a href="/home" tabindex="12">Cancel</a>
       </div>
     </form>
   </div>


### PR DESCRIPTION
Set explicit tab indexes for campaign fields. Order is as follows:

1. Campaign title
2. Federal: Senate (if enabled)
3. Federal: House (if enabled)
4. State: Senate (if enabled)
5. State: Assembly (if enabled)
6. State select dropdown (if visible)
7. Script
8. Thank you message
9. Learn more URL
10. Save as draft
11. Submit
12. Cancel

Tab-selecting the state dropdown will bring it into focus (but not expand it). To expand it, you can either click it or hit the spacebar. While the dropdown is focused, you can also begin typing your state name to select it.

By default, Safari will ignore the legislative checkbox tab indexes unless some settings are changed in Preferences -> Advanced -> Press tab to highlight each item on a page