### PR TITLE
fix .section-header css

### DIFF
--- a/public/scss/main.scss
+++ b/public/scss/main.scss
@@ -28,8 +28,7 @@ a, a:hover {
 .section-header {
     font-size: 1.1em;
     text-transform: uppercase;
-    font-weight: medium;
-    letter-spacing: .2;
+    font-weight: bold;
 }
 
 .body-copy {


### PR DESCRIPTION
resolves #220 

|   | before | after|
|---|---|---|
| mobile | <img width="410" alt="Screen Shot 2019-06-03 at 7 45 51 PM" src="https://user-images.githubusercontent.com/17886804/58847643-9a81d000-8638-11e9-97d7-a2270283285f.png"> | <img width="412" alt="Screen Shot 2019-06-03 at 7 46 13 PM" src="https://user-images.githubusercontent.com/17886804/58847648-9e155700-8638-11e9-820c-6b3c06c561c8.png">  |
| desktop | <img width="1420" alt="Screen Shot 2019-06-03 at 7 45 43 PM" src="https://user-images.githubusercontent.com/17886804/58847639-96ee4900-8638-11e9-894a-d85b0bc3a4e2.png">  | <img width="1424" alt="Screen Shot 2019-06-03 at 7 46 05 PM" src="https://user-images.githubusercontent.com/17886804/58847647-9c4b9380-8638-11e9-9165-1194add68e54.png">  |



