### PR TITLE
[#244] query strings no longer break address searches

### DIFF
--- a/public/js/campaign/visitor.controller.js
+++ b/public/js/campaign/visitor.controller.js
@@ -3,10 +3,8 @@ import angular from 'angular';
 export default angular.module('helloGov')
     .controller('visitorController', function ($scope, $http, $location, constants) {
         'ngInject';
-        // FIXME: this is super brittle to get the campaignId like this, but we're not using angular's
-        // routing so it's not possible to get it using angular yet
-        var urlSplit = $location.absUrl().split('/');
-        $scope.campaign = urlSplit.pop();
+        // FIXME: less brittle way to get campaignId, but still not using Angular's router
+        $scope.campaign = new URL($location.absUrl()).pathname.replace(/[/]/g, '');
         $scope.locResult = '';
         $scope.locOptions = null;
         $scope.locDetails = '';


### PR DESCRIPTION
Switched up the way we pull the campaign ID from the URL on a campaign page. In the tests I did, search params in the URL no longer break address search form submission.

If this new method works, we can also apply it to a few other files that have FIXME comments related to campaign IDs in the URL.