### PR TITLE
[#151] Add basic analytics to Campaign list page

### DIFF
--- a/app/views/campaign.hbs
+++ b/app/views/campaign.hbs
@@ -57,12 +57,12 @@
       </div>
 
       <a ng-repeat-end ng-show="rep.legislatorFound" id="call-btn"
-        class="btn btn-lg call-button center-block primary-button" role="button" href="tel:{[{rep.phone}]}">
+        class="btn btn-lg call-button center-block primary-button" role="button" href="tel:{[{rep.phone}]}"
+        ng-click="sendEvent('call')">
         Make the call now!
       </a>
 
-      <a class="btn btn-lg call-button center-block secondary-button" role="button" href="{{campData.url}}/thank-you"
-        ng-click="sendEvent('call')">
+      <a class="btn btn-lg call-button center-block secondary-button" role="button" href="{{campData.url}}/thank-you">
         I'm done
       </a>
 

--- a/public/js/home/campaigns-list.component.js
+++ b/public/js/home/campaigns-list.component.js
@@ -18,6 +18,12 @@ export default angular.module('helloGov')
                         self.campaigns = result.data;
                         self.campaigns.forEach(element => {
                             $scope.showComfirmFlags[element.id] = false; // initialize not showing delete-confirm
+                        // $http.get(`${constants.API_ROOT}/events?campaignId=${$scope.campaignId}`, $scope.analytics)
+                        // .then(function(result) {
+                        //     $scope.analytics = result.data;
+                        // })
+                        // .catch(function(data) {
+                        //     console.log(`Error:  ${JSON.stringify(data)}`);
                         });
                     })
                     .catch(function (data) {

--- a/public/js/home/campaigns-list.component.js
+++ b/public/js/home/campaigns-list.component.js
@@ -18,12 +18,13 @@ export default angular.module('helloGov')
                         self.campaigns = result.data;
                         self.campaigns.forEach(element => {
                             $scope.showComfirmFlags[element.id] = false; // initialize not showing delete-confirm
-                        // $http.get(`${constants.API_ROOT}/events?campaignId=${$scope.campaignId}`, $scope.analytics)
-                        // .then(function(result) {
-                        //     $scope.analytics = result.data;
-                        // })
-                        // .catch(function(data) {
-                        //     console.log(`Error:  ${JSON.stringify(data)}`);
+                            $http.get(`${constants.API_ROOT}/events?campaignId=${element.id}`)
+                            .then(function(result) {
+                                element.analytics = result.data;
+                            })
+                            .catch(function(data) {
+                                console.log(`Error:  ${JSON.stringify(data)}`);
+                            });
                         });
                     })
                     .catch(function (data) {

--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -3,7 +3,7 @@
     <br><br>
     <div ng-repeat="campaign in $ctrl.campaigns" class="background-white">
         <div class="campaign-info">
-            <div class="sidebar">
+            <!-- <div class="sidebar">
                 <div class="date">
                     <div class="date-label">created:</div>
                     <div class="date-container">
@@ -11,20 +11,12 @@
                         <div class="date-bottom">{[{campaign.createdAt | date: 'yyyy'}]}</div>
                     </div>
                 </div>
-            </div>
-            <div class="analytics">
-                <div class="analytics-container">
-                    <p class="analytics-number">{[{campaign.analytics.call}]}</p>
-                    <p>Calls</p>
-                </div>
-                <div class="analytics-container">
-                    <p class="analytics-number">{[{campaign.analytics.visit}]}</p>
-                    <p>Visits</p>
-                </div>
-            </div>
-            <div class="content">
+            </div> -->
+            <div class="title">
                 <h4 class="campaign-title">{[{campaign.title}]}</h4>
                 <h5 ng-if="!campaign.publish">DRAFT</h5>
+            </div>
+            <div class="content">
                 <div class="text-center">
                     <div class="option-button-container">
                         <!-- TODO: Update analytics link when we have individual pages for each campaign -->
@@ -58,6 +50,22 @@
                     </div>
                 </div>
             </div>
+            <div class="date">
+                <small class="date">Created: {[{campaign.createdAt | date: 'MMM d, yyyy'}]}</small>
+            </div>
+            <label>
+                <input type="checkbox" class="toggleAnalytics"/>
+                <div class="analytics">
+                    <div class="analytics-container">
+                        <p class="analytics-number">{[{campaign.analytics.call}]}</p>
+                        <p>Calls</p>
+                    </div>
+                    <div class="analytics-container">
+                        <p class="analytics-number">{[{campaign.analytics.visit}]}</p>
+                        <p>Visits</p>
+                    </div>
+                </div>
+            </label>
         </div>
     </div>
 </div>

--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -30,23 +30,16 @@
                     </div></a>
                     <div>
                         <div class="option-button">
-                            <p class="analytics-display">{[{analytics.call}]}</p>
+                            <p class="analytics-display">{[{campaign.analytics.call}]}</p>
                             <p>Calls</p>
                         </div>
                         <div class="option-button">
-                            <p class="analytics-display">{[{analytics.visit}]}</p>
+                            <p class="analytics-display">{[{campaign.analytics.visit}]}</p>
                             <p>Visits</p>
                         </div>
                     </div>
                 </div>
-                <a ng-href="{[{campaign.url}]}/edit"><div class="option-button">
-                    <input type="image" src="/images/pencil.jpg" />
-                    <p>Edit</p>
-                </div></a>
-                <a><div ng-click="$ctrl.confirm(campaign.id)" class="option-button">
-                    <input type="image" src="/images/white_delete_icon.jpg" />
-                    <p>Delete</p>
-                </div></a>
+
                 <div id="confirm-delete" ng-show="showComfirmFlags[campaign.id]">
                     <a ng-click="$ctrl.delete(campaign.id)" class="btn delete-button">Really, Delete</a>
                     <a ng-click="$ctrl.cancel(campaign.id)" class="btn secondary-button">Cancel</a>

--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -7,15 +7,37 @@
             <h4>{[{campaign.title}]}</h4>
             <h5 ng-if="!campaign.publish">DRAFT</h5>
             <div class="text-center">
-                <!-- TODO: Update analytics link when we have individual pages for each campaign -->
-                <a href="{[{campaign.url}]}/analytics"><div class="option-button">
-                    <input type="image" src="/images/analytics_icon.svg" />
-                    <p>Analytics</p>
-                </div></a>
-                <!-- TODO: This should give feedback, ideally like in the mockup -->
-                <div class="option-button">
-                    <input type="image" src="/images/white_link_icon.jpg" ngclipboard data-clipboard-text="{[{$ctrl.hostName}]}{[{campaign.url}]}" />
-                    <p>Link</p>
+                <div>
+                    <!-- TODO: Update analytics link when we have individual pages for each campaign -->
+                    <!-- Removed because not enough analytics to dedicate to entire page -->
+                    <!-- <a href="{[{campaign.url}]}/analytics"><div class="option-button">
+                        <input type="image" src="/images/analytics_icon.svg" />
+                        <p>Analytics</p>
+                    </div></a> -->
+                    <!-- TODO: This should give feedback, ideally like in the mockup -->
+                    <div class="option-button">
+                        <input type="image" src="/images/white_link_icon.jpg" ngclipboard data-clipboard-text="{[{$ctrl.hostName}]}{[{campaign.url}]}" />
+                        <p>Link</p>
+                    </div>
+                    <a ng-href="{[{campaign.url}]}/edit"><div class="option-button">
+                        <input type="image" src="/images/pencil.jpg" />
+                        <p>Edit</p>
+                    </div></a>
+                    <!-- TODO: Show a warning first like in the mockup -->
+                    <a ng-click="$ctrl.delete(campaign.id)"><div class="option-button">
+                        <input type="image" src="/images/white_delete_icon.jpg" />
+                        <p>Delete</p>
+                    </div></a>
+                    <div>
+                        <div class="option-button">
+                            <p class="analytics-display">{[{analytics.call}]}</p>
+                            <p>Calls</p>
+                        </div>
+                        <div class="option-button">
+                            <p class="analytics-display">{[{analytics.visit}]}</p>
+                            <p>Visits</p>
+                        </div>
+                    </div>
                 </div>
                 <a ng-href="{[{campaign.url}]}/edit"><div class="option-button">
                     <input type="image" src="/images/pencil.jpg" />

--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -3,46 +3,56 @@
     <br><br>
     <div ng-repeat="campaign in $ctrl.campaigns" class="background-white">
         <div class="campaign-info">
-            <h5 class="campaign-date">{[{campaign.createdAt | date: 'longDate'}]}</h5>
-            <h4>{[{campaign.title}]}</h4>
-            <h5 ng-if="!campaign.publish">DRAFT</h5>
-            <div class="text-center">
-                <div>
-                    <!-- TODO: Update analytics link when we have individual pages for each campaign -->
-                    <!-- Removed because not enough analytics to dedicate to entire page -->
-                    <!-- <a href="{[{campaign.url}]}/analytics"><div class="option-button">
-                        <input type="image" src="/images/analytics_icon.svg" />
-                        <p>Analytics</p>
-                    </div></a> -->
-                    <!-- TODO: This should give feedback, ideally like in the mockup -->
-                    <div class="option-button">
-                        <input type="image" src="/images/white_link_icon.jpg" ngclipboard data-clipboard-text="{[{$ctrl.hostName}]}{[{campaign.url}]}" />
-                        <p>Link</p>
-                    </div>
-                    <a ng-href="{[{campaign.url}]}/edit"><div class="option-button">
-                        <input type="image" src="/images/pencil.jpg" />
-                        <p>Edit</p>
-                    </div></a>
-                    <!-- TODO: Show a warning first like in the mockup -->
-                    <a ng-click="$ctrl.delete(campaign.id)"><div class="option-button">
-                        <input type="image" src="/images/white_delete_icon.jpg" />
-                        <p>Delete</p>
-                    </div></a>
-                    <div>
-                        <div class="option-button">
-                            <p class="analytics-display">{[{campaign.analytics.call}]}</p>
-                            <p>Calls</p>
-                        </div>
-                        <div class="option-button">
-                            <p class="analytics-display">{[{campaign.analytics.visit}]}</p>
-                            <p>Visits</p>
-                        </div>
+            <div class="sidebar">
+                <div class="date">
+                    <div class="date-label">created:</div>
+                    <div class="date-container">
+                        <div class="date-top">{[{campaign.createdAt | date: 'MMM dd'}]}</div>
+                        <div class="date-bottom">{[{campaign.createdAt | date: 'yyyy'}]}</div>
                     </div>
                 </div>
+            </div>
+            <div class="analytics">
+                <div class="analytics-container">
+                    <p class="analytics-number">{[{campaign.analytics.call}]}</p>
+                    <p>Calls</p>
+                </div>
+                <div class="analytics-container">
+                    <p class="analytics-number">{[{campaign.analytics.visit}]}</p>
+                    <p>Visits</p>
+                </div>
+            </div>
+            <div class="content">
+                <h4 class="campaign-title">{[{campaign.title}]}</h4>
+                <h5 ng-if="!campaign.publish">DRAFT</h5>
+                <div class="text-center">
+                    <div>
+                        <!-- TODO: Update analytics link when we have individual pages for each campaign -->
+                        <!-- Removed because not enough analytics to dedicate to entire page -->
+                        <!-- <a href="{[{campaign.url}]}/analytics"><div class="option-button">
+                            <input type="image" src="/images/analytics_icon.svg" />
+                            <p>Analytics</p>
+                        </div></a> -->
+                        <!-- TODO: This should give feedback, ideally like in the mockup -->
+                        <div class="option-button">
+                            <input type="image" src="/images/white_link_icon.jpg" ngclipboard data-clipboard-text="{[{$ctrl.hostName}]}{[{campaign.url}]}" />
+                            <p>Link</p>
+                        </div>
+                        <a ng-href="{[{campaign.url}]}/edit"><div class="option-button">
+                            <input type="image" src="/images/pencil.jpg" />
+                            <p>Edit</p>
+                        </div></a>
+                        <!-- TODO: Show a warning first like in the mockup -->
+                        <a ng-click="$ctrl.delete(campaign.id)"><div class="option-button">
+                            <input type="image" src="/images/white_delete_icon.jpg" />
+                            <p>Delete</p>
+                        </div></a>
+                    </div>
 
-                <div id="confirm-delete" ng-show="showComfirmFlags[campaign.id]">
-                    <a ng-click="$ctrl.delete(campaign.id)" class="btn delete-button">Really, Delete</a>
-                    <a ng-click="$ctrl.cancel(campaign.id)" class="btn secondary-button">Cancel</a>
+                    <div id="confirm-delete" ng-show="showComfirmFlags[campaign.id]">
+                        <a ng-click="$ctrl.delete(campaign.id)" class="btn delete-button">Really, Delete</a>
+                        <a ng-click="$ctrl.cancel(campaign.id)" class="btn secondary-button">Cancel</a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -3,15 +3,6 @@
     <br><br>
     <div ng-repeat="campaign in $ctrl.campaigns" class="background-white">
         <div class="campaign-info">
-            <!-- <div class="sidebar">
-                <div class="date">
-                    <div class="date-label">created:</div>
-                    <div class="date-container">
-                        <div class="date-top">{[{campaign.createdAt | date: 'MMM dd'}]}</div>
-                        <div class="date-bottom">{[{campaign.createdAt | date: 'yyyy'}]}</div>
-                    </div>
-                </div>
-            </div> -->
             <div class="title">
                 <h4 class="campaign-title">{[{campaign.title}]}</h4>
                 <h5 ng-if="!campaign.publish">DRAFT</h5>
@@ -19,12 +10,6 @@
             <div class="content">
                 <div class="text-center">
                     <div class="option-button-container">
-                        <!-- TODO: Update analytics link when we have individual pages for each campaign -->
-                        <!-- Removed because not enough analytics to dedicate to entire page -->
-                        <!-- <a href="{[{campaign.url}]}/analytics"><div class="option-button">
-                            <input type="image" src="/images/analytics_icon.svg" />
-                            <p>Analytics</p>
-                        </div></a> -->
                         <!-- TODO: This should give feedback, ideally like in the mockup -->
                         <div class="option-button">
                             <input type="image" src="/images/white_link_icon.jpg" ngclipboard data-clipboard-text="{[{$ctrl.hostName}]}{[{campaign.url}]}" />
@@ -34,7 +19,6 @@
                             <input type="image" src="/images/pencil.jpg" />
                             <p>Edit</p>
                         </div></a>
-                        <!-- TODO: Show a warning first like in the mockup -->
                         <a ng-click="$ctrl.confirm(campaign.id)"><div class="option-button">
                             <input type="image" src="/images/white_delete_icon.jpg" />
                             <p>Delete</p>

--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -43,15 +43,18 @@
                             <p>Edit</p>
                         </div></a>
                         <!-- TODO: Show a warning first like in the mockup -->
-                        <a ng-click="$ctrl.delete(campaign.id)"><div class="option-button">
+                        <a ng-click="$ctrl.confirm(campaign.id)"><div class="option-button">
                             <input type="image" src="/images/white_delete_icon.jpg" />
                             <p>Delete</p>
                         </div></a>
                     </div>
 
-                    <div id="confirm-delete" ng-show="showComfirmFlags[campaign.id]">
-                        <a ng-click="$ctrl.delete(campaign.id)" class="btn delete-button">Really, Delete</a>
-                        <a ng-click="$ctrl.cancel(campaign.id)" class="btn secondary-button">Cancel</a>
+                    <div id="confirm-delete-container" ng-show="showComfirmFlags[campaign.id]">
+                        <div id="confirm-delete">
+                            <p>Are you sure you want to delete?</p>
+                            <a ng-click="$ctrl.delete(campaign.id)" class="btn delete-button">Delete</a>
+                            <a ng-click="$ctrl.cancel(campaign.id)" class="btn secondary-button">Cancel</a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -26,7 +26,7 @@
                 <h4 class="campaign-title">{[{campaign.title}]}</h4>
                 <h5 ng-if="!campaign.publish">DRAFT</h5>
                 <div class="text-center">
-                    <div>
+                    <div class="option-button-container">
                         <!-- TODO: Update analytics link when we have individual pages for each campaign -->
                         <!-- Removed because not enough analytics to dedicate to entire page -->
                         <!-- <a href="{[{campaign.url}]}/analytics"><div class="option-button">

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -34,7 +34,6 @@
         background: $blue-light;
         color: white;
         flex-basis: 100%;
-        // border-left: 1px solid $blue-light;
         padding: 20px 0px;
         display: flex;
         flex-flow: column nowrap;
@@ -120,9 +119,6 @@
         .toggleAnalytics:checked + .analytics {
             height: calc(100% - 75px);
         }
-        // .analytics:hover {
-        //     height: calc(100% - 75px);
-        // }
         .analytics::after {
             content: "analytics";
             font-size: 0.5em;

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -6,65 +6,43 @@
     font-weight: bold;
     border: 1px solid $blue-light;
     display: flex;
+    flex-flow: column wrap;
+    justify-content: space-between;
+    height: 252px;
+    position: relative;
 
-    @media (max-width: $tablet-min) {
-        flex-flow: column nowrap;
-    }
+    .title {
+        height: 75px;
 
-    .sidebar {
-        flex-grow: 1;
-        background: $blue-light;
-        color: white;
-        .date {
-            padding: 20px 0px;
-            display: inline-block;
-            @media (max-width: $tablet-min) {
-                padding: 5px 0px;
-            }
-            .date-label {
-                font-weight: 100;
-                font-size: 0.5em;
-                border-bottom: 1px dotted white;
-                margin-bottom: 10px;
-                display: inline-block;
-            }
-            .date-container {
-                @media (max-width: $tablet-min) {
-                    display: flex;
-                    .date-top::after {
-                        content: ", ";
-                        padding-right: 1rem;
-                    }
-                }
-                .date-top {
-                    font-size: 1.0em;
-                    font-weight: 100;
-                }
-                .date-bottom {
-                    font-size: 1.1em;
-                    font-weight: normal;
-                    @media (max-width: $tablet-min) {
-                        font-size: 1.0em;
-                    }
-                }
-            }
+        h4 {
+            font-size: 1.6em;
+            font-weight: bold;
         }
     }
+
+    .date {
+        color: lightgray;
+        font-size: 0.65em;
+        font-weight: 100;
+        height: 30px;
+    }
+
+    .toggleAnalytics {
+        display: none;
+    }
     .analytics {
-        flex-grow: 2;
-        border-right: 1px solid lightgray;
-        margin: 20px 0px;
+        background: $blue-light;
+        color: white;
+        flex-basis: 100%;
+        // border-left: 1px solid $blue-light;
+        padding: 20px 0px;
         display: flex;
         flex-flow: column nowrap;
         justify-content: space-around;
         align-items: center;
-
-        @media (max-width: $tablet-min) {
-            flex-flow: row nowrap;
-            border-right: 0;
-            border-bottom: 1px solid lightgray;
-            margin: 10px 20px;
-        }
+        height: 250px;
+        width: 150px;
+        order: 100;
 
         .analytics-container {
             padding: 10px 0px;
@@ -80,11 +58,8 @@
         flex-flow: column nowrap;
         align-items: center;
         justify-content: space-evenly;
-
-        .campaign-title {
-            font-size: 1.6em;
-            font-weight: bold;
-        }
+        height: 125px;
+        width: calc(100% - 150px);
 
         .analytics-display {
             font-size: 1.2em;
@@ -117,6 +92,73 @@
             margin: 5px auto;
         }
     }
+
+    @media (max-width: $tablet-min) {
+        flex-flow: column nowrap;
+        height: auto;
+        .date {
+            height: auto;
+            order: 3;
+            margin-bottom: 2em;
+        }
+        .analytics {
+            flex-flow: row nowrap;
+            border-left: 0;
+            padding: 10px 20px;
+            order: 4;
+            width: auto;
+            height: 10px;
+            overflow: hidden;
+            flex-basis: unset;
+            align-items: flex-end;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            transition: height 0.5s;
+        }
+        .toggleAnalytics:checked + .analytics {
+            height: calc(100% - 75px);
+        }
+        // .analytics:hover {
+        //     height: calc(100% - 75px);
+        // }
+        .analytics::after {
+            content: "analytics";
+            font-size: 0.5em;
+            font-weight: 100;
+            text-transform: uppercase;
+            position: absolute;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            margin: 0.2em;
+            transition: 0.25s;
+        }
+        .toggleAnalytics:checked + .analytics::after {
+            opacity: 0;
+        }
+        .analytics::before {
+            content: "";
+            position: absolute;
+            top: 0.3em;
+            right: 0.3em;
+            bottom: 0;
+            height: 10px;
+            width: 10px;
+            border: 2px solid white;
+            border-width: 2px 2px 0 0;
+            transform: rotate(-45deg);
+            transition: 0.25s;
+        }
+        .toggleAnalytics:checked + .analytics::before {
+            transform: rotate(135deg);
+        }
+        .content {
+            height: auto;
+            width: auto;
+        }
+    }
 }
 
 #confirm-delete-container {
@@ -129,6 +171,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: 10;
 }
 
 #confirm-delete {

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -18,6 +18,9 @@
         .date {
             padding: 20px 0px;
             display: inline-block;
+            @media (max-width: $tablet-min) {
+                padding: 5px 0px;
+            }
             .date-label {
                 font-weight: 100;
                 font-size: 0.5em;
@@ -26,6 +29,13 @@
                 display: inline-block;
             }
             .date-container {
+                @media (max-width: $tablet-min) {
+                    display: flex;
+                    .date-top::after {
+                        content: ", ";
+                        padding-right: 1rem;
+                    }
+                }
                 .date-top {
                     font-size: 1.0em;
                     font-weight: 100;
@@ -33,6 +43,9 @@
                 .date-bottom {
                     font-size: 1.1em;
                     font-weight: normal;
+                    @media (max-width: $tablet-min) {
+                        font-size: 1.0em;
+                    }
                 }
             }
         }
@@ -81,6 +94,10 @@
             display: inline-block;
             border-bottom: 1px solid $blue-light;
             padding-bottom: 6px;
+        }
+
+        .option-button-container {
+            display: flex;
         }
 
         .option-button {

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -1,36 +1,105 @@
 .campaign-info {
     background-color: $white;
-    padding: 8px 0;
+    padding: 0;
     margin: 10px auto;
     color: $blue-light;
     font-weight: bold;
+    border: 1px solid $blue-light;
+    display: flex;
 
-    .analytics-display {
-        font-size: 1.2em;
+    @media (max-width: $tablet-min) {
+        flex-flow: column nowrap;
     }
 
-    .campaign-date {
-        display: inline-block;
-        border-bottom: 1px solid $blue-light;
-        padding-bottom: 6px;
+    .sidebar {
+        flex-grow: 1;
+        background: $blue-light;
+        color: white;
+        .date {
+            padding: 20px 0px;
+            display: inline-block;
+            .date-label {
+                font-weight: 100;
+                font-size: 0.5em;
+                border-bottom: 1px dotted white;
+                margin-bottom: 10px;
+                display: inline-block;
+            }
+            .date-container {
+                .date-top {
+                    font-size: 1.0em;
+                    font-weight: 100;
+                }
+                .date-bottom {
+                    font-size: 1.1em;
+                    font-weight: normal;
+                }
+            }
+        }
     }
+    .analytics {
+        flex-grow: 2;
+        border-right: 1px solid lightgray;
+        margin: 20px 0px;
+        display: flex;
+        flex-flow: column nowrap;
+        justify-content: space-around;
+        align-items: center;
 
-    .option-button {
-        display: inline-block;
-        width: 4em;
-        margin: 0 .5em;
-        color: $blue-light;
+        @media (max-width: $tablet-min) {
+            flex-flow: row nowrap;
+            border-right: 0;
+            border-bottom: 1px solid lightgray;
+            margin: 10px 20px;
+        }
+
+        .analytics-container {
+            padding: 10px 0px;
+            font-size: 0.75em;
+            .analytics-number {
+                font-size: 1.2em;
+            }
+        }
     }
+    .content {
+        flex-grow: 3;
+        display: flex;
+        flex-flow: column nowrap;
+        align-items: center;
+        justify-content: space-evenly;
 
-    p {
-        margin: 12px auto 0;
-        font-size: 10px;
-    }
+        .campaign-title {
+            font-size: 1.6em;
+            font-weight: bold;
+        }
 
-    .option-button input {
-        height: 40px;
-        display: block;
-        margin: 5px auto;
+        .analytics-display {
+            font-size: 1.2em;
+        }
+
+        .campaign-date {
+            display: inline-block;
+            border-bottom: 1px solid $blue-light;
+            padding-bottom: 6px;
+        }
+
+        .option-button {
+            display: inline-block;
+            width: 4em;
+            margin: 0 .5em;
+            color: $blue-light;
+        }
+
+        p {
+            margin: 12px auto 0;
+            font-size: 10px;
+        }
+
+        .option-button input {
+            height: 40px;
+            display: block;
+            margin: 5px auto;
+        }
     }
 }
 

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -5,6 +5,10 @@
     color: $blue-light;
     font-weight: bold;
 
+    .analytics-display {
+        font-size: 1.2em;
+    }
+
     .campaign-date {
         display: inline-block;
         border-bottom: 1px solid $blue-light;

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -91,8 +91,7 @@
         }
 
         p {
-            margin: 12px auto 0;
-            font-size: 10px;
+            font-weight: normal;
         }
 
         .option-button input {
@@ -103,4 +102,21 @@
     }
 }
 
+#confirm-delete-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#confirm-delete {
+    background: $white;
+    padding: 20px;
+    font-size: 1em;
+}
 


### PR DESCRIPTION
resolves #151 

# Motivation and context
As an admin I want data about how many people have viewed/called my campaign so that I know how effective it has been. Originally we thought we would make this its own analytics page, but for the time being with only two figures it seemed appropriate to add it to the campaign list.

@jschnapper made a good start on this issue in his PR #203. Unfortunately since he hasn't been in contact with us recently his PR had to be closed, but I have picked up where he left off!

# Screenshots
| | before | after |
|---|---|---|
| **mobile** | <img width="340" alt="Screen Shot 2019-06-11 at 7 27 23 AM" src="https://user-images.githubusercontent.com/17886804/59280404-63a05100-8c1a-11e9-96ca-0f542b619d34.png"> | ![Untitled4](https://user-images.githubusercontent.com/17886804/60064263-b23afa00-96b4-11e9-8237-524b2480671d.gif) |
| **desktop** | <img width="1158" alt="Screen Shot 2019-06-11 at 7 27 14 AM" src="https://user-images.githubusercontent.com/17886804/59280453-77e44e00-8c1a-11e9-9c09-ef39921f50f9.png"> | <img width="1358" alt="Screen Shot 2019-06-24 at 7 17 47 PM" src="https://user-images.githubusercontent.com/17886804/60064293-c8e15100-96b4-11e9-8cdd-e4ba7ee9c711.png"> |


# What I did
- move the "call" analytics event from the "I'm done" button to the "call" button
- add the analytics request to the campaign list page
- add analytics to campaign list items and update the UI
