### PR TITLE
New URL parsing method

### DIFF
--- a/public/js/account/resetPassword.component.js
+++ b/public/js/account/resetPassword.component.js
@@ -5,11 +5,9 @@ export default angular.module('helloGov')
     template: require('./resetPassword.html'),
     controller: function($scope, $http, $window, constants, $location) {
         'ngInject';
-        // FIXME: this is super brittle to get the resetToken like this, but we're not using angular's
-        // routing so it's not possible to get it using angular yet
         const self = this;
-        let urlSplit = $location.absUrl().split('/');
-        let resetToken = urlSplit[urlSplit.length - 1];
+        // FIXME: less brittle way to get resetToken, but still not using Angular's router
+        let resetToken = new URL($location.absUrl()).pathname.replace('/auth/reset-password/').replace(/[/]/g, '');
 
         this.resetDetails = {
             resetToken: resetToken

--- a/public/js/account/signupPage.component.js
+++ b/public/js/account/signupPage.component.js
@@ -9,10 +9,8 @@ export default angular.module('helloGov')
         this.signupDetails = {};
 
         this.$onInit = function() {
-            // FIXME: this is super brittle to get the signupId like this, but we're not using angular's
-            // routing so it's not possible to get it using angular yet
-            let urlSplit = $location.absUrl().split('/');
-            let signupId = urlSplit[urlSplit.length - 1];
+            // FIXME: less brittle way to get signupId, but still not using Angular's router
+            let signupId = new URL($location.absUrl()).pathname.replace('/signup/', '');
             $http.get(`${constants.API_ROOT}/signups/${signupId}`)
                 .then((resp) => {
                     self.signupDetails.signupLink = resp.data.result.signupLink;

--- a/public/js/analytics/analyticsPage.component.js
+++ b/public/js/analytics/analyticsPage.component.js
@@ -5,10 +5,8 @@ export default angular.module('helloGov')
     template: require('./analyticsPage.html'),
     controller: function($scope, $http, $location, constants) {
         'ngInject';
-        // FIXME: this is super brittle to get the campaignId like this, but we're not using angular's
-        // routing so it's not possible to get it using angular yet
-        var urlSplit = $location.absUrl().split('/');
-        $scope.campaignId = urlSplit[urlSplit.length - 2];
+        // FIXME: less brittle way to get campaignId, but still not using Angular's router
+        $scope.campaignId = new URL($location.absUrl()).pathname.replace('analytics', '').replace(/[/]/g, '');
 
         $http.get(`${constants.API_ROOT}/campaigns/${$scope.campaignId}`, $scope.campaign)
         .then(function(result) {

--- a/public/js/campaign/thanksPage.component.js
+++ b/public/js/campaign/thanksPage.component.js
@@ -5,11 +5,8 @@ export default angular.module('helloGov')
     template: require('./thanksPage.html'),
     controller: function($http, $location, constants) {
         'ngInject';
-        // FIXME: this is super brittle to get the campaignId like this, but we're not using angular's
-        // routing so it's not possible to get it using angular yet
-        let url = $location.absUrl();
-        let urlSplit = url.split('/');
-        let campaignId = urlSplit[urlSplit.length - 2];
+        // FIXME: less brittle way to get campaignId, but still not using Angular's router
+        let campaignId = new URL($location.absUrl()).pathname.replace('/thank-you', '').replace(/[/]/g, '');
 
         $http.get(`${constants.API_ROOT}/campaigns/${campaignId}`)
             .then((resp) => {

--- a/public/js/create/createPage.component.js
+++ b/public/js/create/createPage.component.js
@@ -12,13 +12,12 @@ export default angular.module('helloGov')
             $scope.stateSenateSelected = false;
             $scope.stateAssemblySelected = false;
 
-            // FIXME: this is super brittle to get the campaignId like this, but we're not using angular's
-            // routing so it's not possible to get it using angular yet
-            let urlSplit = $location.absUrl().split('/');
+            // FIXME: less brittle way to get campaignId, but still not using Angular's router
+            let url = new URL($location.absUrl());
 
             // if on an edit page, then grab the campaignId from URL
-            if (urlSplit.indexOf('edit') !== -1) {
-                var campaignId = urlSplit[urlSplit.length - 2];
+            if (url.pathname.indexOf('/edit') !== -1) {
+                var campaignId = url.pathname.replace('/edit', '').replace(/[/]/g, '');
                 isNew = false;
 
                 $http.get(`${constants.API_ROOT}/campaigns/${campaignId}`)

--- a/public/js/create/createSuccessPage.component.js
+++ b/public/js/create/createSuccessPage.component.js
@@ -5,13 +5,11 @@ export default angular.module('helloGov')
     template: require('./createSuccessPage.html'),
     controller: function($http, $location, constants) {
         'ngInject';
-        // FIXME: this is super brittle to get the campaignId like this, but we're not using angular's
-        // routing so it's not possible to get it using angular yet
-        let url = $location.absUrl();
-        let urlSplit = url.split('/');
-        let campaignId = urlSplit[urlSplit.length - 2];
+        // FIXME: less brittle way to get campaignId, but still not using Angular's router
+        let url = new URL($location.absUrl());
+        let campaignId = url.pathname.replace('/success', '').replace(/[/]/g, '');
 
-        this.campaignFullUrl = url.replace('/success', '');
+        this.campaignFullUrl = url.href.replace('/success', '');
         $http.get(`${constants.API_ROOT}/campaigns/${campaignId}`)
             .then((resp) => {
                 this.campaign = resp.data;


### PR DESCRIPTION
I implemented the URL parsing method from #249 in a few other places in our code where there are FIXMEs referencing brittle URL parsing. 

There will be some instances where the final .replace(/[/]/g, '') call (which strips out any '/' characters) will be unnecessary. This is done to make doubly sure that if a trailing slash does get added to the URL for whatever reason, it won't affect the app's ability to parse out what it needs.