### PR TITLE
[#258] Add field length feedback to campaign form

### DIFF
--- a/public/js/create/createPage.html
+++ b/public/js/create/createPage.html
@@ -167,7 +167,7 @@
         </div>
         <p>Link to a page on your org's website about the issue.</p>
         <textarea name="learn_more" class="form-control input-lg campaign-input" ng-model="$ctrl.campaign.learn_more"
-          rows="2" maxlength="200" ng-trim="false" type="url" tabindex="9">
+          rows="2" maxlength="200" ng-trim="false" placeholder="Ex: https://www.google.com" type="url" tabindex="9">
         </textarea>
         <div class="max-text">
             <span> {{$ctrl.campaign.learn_more.length}} / 200 characters

--- a/public/js/create/createPage.html
+++ b/public/js/create/createPage.html
@@ -20,10 +20,13 @@
         </div>
         <p>Displays to supporter, so it should read as a call-to-action</p>
         <textarea name="title" class="form-control input-lg campaign-input" ng-class="{'form-field-error': createForm.title.$touched && createForm.title.$invalid}"
-          ng-model="$ctrl.campaign.title" rows="2" maxlength="140" placeholder="Ex: 'Vote YES on SB280.'"required
+          ng-model="$ctrl.campaign.title" rows="2" maxlength="140" ng-trim="false" placeholder="Ex: 'Vote YES on SB280.'"required
           tabindex="1">
         </textarea>
-        <div class="max-text">Max 140 characters</div>
+        <div class="max-text">
+            <span> {{$ctrl.campaign.title.length}} / 140 characters
+            </span>
+        </div>
       </div>
 
       <div class="form-group">
@@ -135,9 +138,13 @@
         </div>
         <p>Suggest wording to your supporter</p>
         <textarea name="script" class="form-control input-lg campaign-input" ng-class="{'form-field-error': createForm.script.$touched && createForm.script.$invalid}"
-          ng-model="$ctrl.campaign.script" rows="6" maxlength="800" required tabindex="7">
+          ng-model="$ctrl.campaign.script" rows="6" maxlength="800" ng-trim="false" required tabindex="7">
         </textarea>
-        <div class="max-text">Max 800 characters</div>
+        <div class="max-text">
+            <span> {{$ctrl.campaign.script.length}} / 800 characters
+            </span>
+        </div>
+
       </div>
 
       <div class="form-group">
@@ -146,21 +153,26 @@
         </div>
         <p>Displays when your supporter finishes their call</p>
         <textarea name="thank_you" class="form-control input-lg campaign-input" ng-class="{'form-field-error': createForm.thank_you.$touched && createForm.thank_you.$invalid}"
-          ng-model="$ctrl.campaign.thank_you" rows="4" maxlength="250"  placeholder="Appears after a call is made." required
+          ng-model="$ctrl.campaign.thank_you" rows="4" maxlength="250" ng-trim="false" placeholder="Appears after a call is made." required
           tabindex="8">
         </textarea>
-        <div class="max-text">Max 250 characters</div>
-      </div>
+        <div class="max-text">
+            <span> {{$ctrl.campaign.thank_you.length}} / 250 characters
+            </span>
+        </div>
 
       <div class="form-group">
         <div class="prompt-title">
           <h4>LEARN MORE URL</h4>
         </div>
+        <p>Link to a page on your org's website about the issue.</p>
         <textarea name="learn_more" class="form-control input-lg campaign-input" ng-model="$ctrl.campaign.learn_more"
-          rows="2" maxlength="200" placeholder="Link to a page on your org's website about the issue." tabindex="9">
+          rows="2" maxlength="200" ng-trim="false" type="url" tabindex="9">
         </textarea>
-        <div class="max-text">Max 200 characters</div>
-      </div>
+        <div class="max-text">
+            <span> {{$ctrl.campaign.learn_more.length}} / 200 characters
+            </span>
+        </div>
 
       <div class="errors" ng-if="error">
         {[{error}]}


### PR DESCRIPTION
Fixes: #258 

Changes campaign creation fields from  'Max 800 characters' to dynamic '70/800'.
Additionally, the Learn More URL `<textarea>` is checked for validity.

While working on this, I noticed the description at the top of the create page says the following:
> Optionally, you can add a link for them to learn more about the topic. 

However, the Submit validation expects a Learn More URL. I may need to open another issue to address this.