### PR TITLE
[#211] Error message for incomplete addresses + partial address filtering

### DIFF
--- a/app/views/campaign.hbs
+++ b/app/views/campaign.hbs
@@ -13,16 +13,19 @@
     </div>
 
     <div class="campaign-circles" ng-show="addrForm" class="ng-hide">
-    <div class="campaign-info">
-      <!-- <h3>Campaign:</h3> -->
-      <h1>{{campData.title}}</h1>
-    </div>
-      <h4>Enter the address where you vote to find the correct representative:</h4>
-      <input id="searchTextField" type="text" ng-map-autocomplete ng-model="locResult" options="locOptions"
-        ng-value="locDetails.formatted_address" details="locDetails" class="form-control input-lg address-search" />
-      <button id="address-submit" type="button" ng-click="update()" class="btn primary-button">Submit</button>
-      <input id="latitude" type="hidden" />
-      <input id="longitude" type="hidden" />
+        <div class="campaign-info">
+            <!-- <h3>Campaign:</h3> -->
+            <h1>{{campData.title}}</h1>
+        </div>
+        <h4>Enter the address where you vote to find the correct representative:</h4>
+        <input id="searchTextField" type="text" ng-map-autocomplete ng-model="locResult" options="locOptions"
+            ng-value="locDetails.formatted_address" details="locDetails" class="form-control input-lg address-search" />
+        <button id="address-submit" type="button" ng-click="update()" class="btn primary-button">Submit</button>
+        <h4 class="text-danger ng-hide" ng-show="invalidAddress">
+            Please enter a complete street address including the house number and street name.
+        </h4>
+        <input id="latitude" type="hidden" />
+        <input id="longitude" type="hidden" />
     </div><!-- end campaign-circles -->
 
     <div id="rep-container" ng-show="repForm" class="ng-hide">

--- a/public/js/campaign/visitor.controller.js
+++ b/public/js/campaign/visitor.controller.js
@@ -6,14 +6,25 @@ export default angular.module('helloGov')
         // FIXME: less brittle way to get campaignId, but still not using Angular's router
         $scope.campaign = new URL($location.absUrl()).pathname.replace(/[/]/g, '');
         $scope.locResult = '';
-        $scope.locOptions = null;
+        $scope.locOptions = {
+            types: 'establishment', // this will filter most (but not) all incomplete addresses
+            watchEnter: true        // pressing enter will autofill the most relevant autocomplete result
+        };
         $scope.locDetails = '';
+        $scope.invalidAddress = false;
 
         $scope.sendEvent = function (type) {
             $http.post(`${constants.API_ROOT}/events`, { type: type, campaign: $scope.campaign });
         };
         $scope.sendEvent('visit');
         $scope.update = function () {
+            // checking for valid address
+            if (!$scope.locDetails || $scope.locDetails.adr_address.indexOf('<span class="street-address">') === -1){
+                $scope.invalidAddress = true;
+                return;
+            }
+            $scope.invalidAddress = false;
+
             let address = $scope.locDetails.formatted_address.replace(/ /g, '%20');
             let latitude = $scope.locDetails.geometry.location.lat();
             let longitude = $scope.locDetails.geometry.location.lng();


### PR DESCRIPTION
Set some config options so that the autocomplete form will (mostly) return complete addresses. Searching for a zip code or city should now return either nothing in the list, or a list of businesses with full addresses that start with those strings. EX: 90210 Car Rental, California Donuts, California Science Center, etc.

There are some weird edge cases where it still returns just a city, state, and zip code (like searching 'Burbank Airport'): 
![partial-highlight](https://user-images.githubusercontent.com/5104274/60461178-a7272300-9bfa-11e9-8197-811fb5f324e9.png)

In those cases we now have an error message:
![message](https://user-images.githubusercontent.com/5104274/60461101-6a5b2c00-9bfa-11e9-8b51-79f3612810c4.png)
