### PR TITLE
[#236] Relative padding for mobile buttons

### DIFF
--- a/public/scss/buttons.scss
+++ b/public/scss/buttons.scss
@@ -6,7 +6,7 @@
     font-size: 1.1em;
     font-weight: bolder;
     letter-spacing: 1px;
-    padding: 0.3em 2em;
+    padding: 1% 2%;
     margin: 10px 0;
     width: 100%;
     text-decoration: none;


### PR DESCRIPTION
Addresses #236

# Motivation and context
Fixes wrapping of text inside button when viewing the *Home* page (and other buttons) on mobile.

# Screenshots
Before
![58064186-f8d98980-7b35-11e9-83cf-1edb68897383](https://user-images.githubusercontent.com/8117210/60856071-cd306280-a1ba-11e9-9893-90813bdecc49.jpeg)

After
<img width="261" alt="Screen Shot 2019-07-08 at 7 57 15 PM" src="https://user-images.githubusercontent.com/8117210/60856014-9eb28780-a1ba-11e9-9d61-a08f1e7139c5.png">

# What I did
- Change button padding to use a percentage. This resolves mobile responsive designs as the measurement is taken with respect to the size of the screen, rather than the absolute unit.
