### PR TITLE
[#278] added checks and redirects on auth pages for logged in users

### DIFF
--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -19,7 +19,11 @@ module.exports = function(router) {
     });
 
     router.get('/login', (request, response) => {
-        response.render('login', {user: null, logged_in: request.user != null});
+        if (request.user) {
+            response.redirect('/home');
+        } else {
+            response.render('login', {user: null, logged_in: request.user != null});
+        }
     });
 
     // Redirect the user to Facebook for authentication.  When complete,
@@ -47,7 +51,11 @@ module.exports = function(router) {
     });
 
     router.get('/auth/forgot-password', (request, response) => {
-        response.render('forgotMyPassword', {user: null, logged_in: request.user != null});
+        if (request.user) {
+            response.redirect('/home');
+        } else {
+            response.render('forgotMyPassword', {user: null, logged_in: request.user != null});
+        }
     });
 
     router.get('/auth/reset-password/:resetToken', (request, response) => {


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #278 <!-- issue number here -->

# Motivation and context
Users shouldn't be allowed to log in again or access the 'forgot password' page if they are already logged in.

# What I did
There are now server-side checks for logged in users upon navigating to <code>/login</code> and <code>/auth/forgot-password</code>. If a user is logged in, they will be redirected to <code>/home</code> in both cases.
