### PR TITLE
[#253] Password length validation for password fields

### DIFF
--- a/app/routes/api/auth.js
+++ b/app/routes/api/auth.js
@@ -30,9 +30,7 @@ router.route('/auth/password')
 
         userPromise.then((user) => {
             user.setPassword(request.body.password, function (err, model, passwordErr) {
-                let lengthError = request.body.password.length < 7 || request.body.password.length > 32;
-
-                if (err || passwordErr || lengthError) {
+                if (err || passwordErr || request.body.password.length < 7) {
                     response.status(400).end();
                 } else {
                     model.save()

--- a/app/routes/api/auth.js
+++ b/app/routes/api/auth.js
@@ -30,7 +30,9 @@ router.route('/auth/password')
 
         userPromise.then((user) => {
             user.setPassword(request.body.password, function (err, model, passwordErr) {
-                if (err || passwordErr || request.body.password.length < 7) {
+                let lengthError = request.body.password.length < 7 || request.body.password.length > 32;
+
+                if (err || passwordErr || lengthError) {
                     response.status(400).end();
                 } else {
                     model.save()

--- a/app/routes/api/auth.js
+++ b/app/routes/api/auth.js
@@ -30,7 +30,7 @@ router.route('/auth/password')
 
         userPromise.then((user) => {
             user.setPassword(request.body.password, function (err, model, passwordErr) {
-                if (err || passwordErr) {
+                if (err || passwordErr || request.body.password.length < 7) {
                     response.status(400).end();
                 } else {
                     model.save()

--- a/public/js/account/resetPassword.html
+++ b/public/js/account/resetPassword.html
@@ -6,12 +6,16 @@
                 <p>Enter in your new password below.</p>
                 <div class="form-group">
                     <input name="password" type="password" class="form-control input-lg" placeholder="Enter new password"
-                        ng-model="$ctrl.resetDetails.password" ng-required="true"
+                        ng-model="$ctrl.resetDetails.password" ng-required="true" ng-minlength="8"
                         ng-class="{'form-field-error': resetPasswordForm.password.$touched && resetPasswordForm.password.$invalid}">
+                    <span class="error-help-text"
+                        ng-if="resetPasswordForm.password.$touched && resetPasswordForm.password.$error.minlength">
+                        Please use a password that is at least 8 characters.
+                    </span>
                 </div>
                 <div class="form-group">
                     <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                        ng-model="$ctrl.resetDetails.passwordConfirm" ng-required="true" match-input="$ctrl.resetDetails.password"
+                        ng-model="$ctrl.resetDetails.passwordConfirm" ng-required="true" match-input="$ctrl.resetDetails.password" ng-minlength="8"
                         ng-class="{'form-field-error': resetPasswordForm.passwordConfirm.$touched && resetPasswordForm.passwordConfirm.$invalid}">
                     <span class="error-help-text" ng-if="resetPasswordForm.passwordConfirm.$touched && resetPasswordForm.passwordConfirm.$error.unique">Passwords must match.</span>
                 </div>

--- a/public/js/account/resetPassword.html
+++ b/public/js/account/resetPassword.html
@@ -6,7 +6,7 @@
                 <p>Enter in your new password below.</p>
                 <div class="form-group">
                     <input name="password" type="password" class="form-control input-lg" placeholder="Enter new password"
-                        ng-model="$ctrl.resetDetails.password" ng-required="true" ng-minlength="8" ng-maxlength="32" maxlength="32"
+                        ng-model="$ctrl.resetDetails.password" ng-required="true" ng-minlength="8"
                         ng-class="{'form-field-error': resetPasswordForm.password.$touched && resetPasswordForm.password.$invalid}">
                     <span class="error-help-text"
                         ng-if="resetPasswordForm.password.$touched && resetPasswordForm.password.$error.minlength">
@@ -15,8 +15,7 @@
                 </div>
                 <div class="form-group">
                     <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                        ng-model="$ctrl.resetDetails.passwordConfirm" ng-required="true" match-input="$ctrl.resetDetails.password"
-                        ng-minlength="8" ng-maxlength="32" maxlength="32"
+                        ng-model="$ctrl.resetDetails.passwordConfirm" ng-required="true" match-input="$ctrl.resetDetails.password" ng-minlength="8"
                         ng-class="{'form-field-error': resetPasswordForm.passwordConfirm.$touched && resetPasswordForm.passwordConfirm.$invalid}">
                     <span class="error-help-text" ng-if="resetPasswordForm.passwordConfirm.$touched && resetPasswordForm.passwordConfirm.$error.unique">Passwords must match.</span>
                 </div>

--- a/public/js/account/resetPassword.html
+++ b/public/js/account/resetPassword.html
@@ -6,7 +6,7 @@
                 <p>Enter in your new password below.</p>
                 <div class="form-group">
                     <input name="password" type="password" class="form-control input-lg" placeholder="Enter new password"
-                        ng-model="$ctrl.resetDetails.password" ng-required="true" ng-minlength="8"
+                        ng-model="$ctrl.resetDetails.password" ng-required="true" ng-minlength="8" ng-maxlength="32" maxlength="32"
                         ng-class="{'form-field-error': resetPasswordForm.password.$touched && resetPasswordForm.password.$invalid}">
                     <span class="error-help-text"
                         ng-if="resetPasswordForm.password.$touched && resetPasswordForm.password.$error.minlength">
@@ -15,7 +15,8 @@
                 </div>
                 <div class="form-group">
                     <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                        ng-model="$ctrl.resetDetails.passwordConfirm" ng-required="true" match-input="$ctrl.resetDetails.password" ng-minlength="8"
+                        ng-model="$ctrl.resetDetails.passwordConfirm" ng-required="true" match-input="$ctrl.resetDetails.password"
+                        ng-minlength="8" ng-maxlength="32" maxlength="32"
                         ng-class="{'form-field-error': resetPasswordForm.passwordConfirm.$touched && resetPasswordForm.passwordConfirm.$invalid}">
                     <span class="error-help-text" ng-if="resetPasswordForm.passwordConfirm.$touched && resetPasswordForm.passwordConfirm.$error.unique">Passwords must match.</span>
                 </div>

--- a/public/js/account/settingsPage.html
+++ b/public/js/account/settingsPage.html
@@ -69,7 +69,7 @@
                 <div class="setting-edit" ng-class="{'collapsed': $ctrl.activeSetting !== 'password'}" ng-form="passwordForm">
                     <div class="form-group">
                         <input name="password" type="password" class="form-control input-lg" placeholder="Password"
-                            ng-model="$ctrl.profile.password" ng-required="true" ng-minlength="8"
+                            ng-model="$ctrl.profile.password" ng-required="true" ng-minlength="8" ng-maxlength="32" maxlength="32"
                             ng-class="{'form-field-error': passwordForm.password.$touched && passwordForm.password.$invalid}">
                         <span class="error-help-text"
                             ng-if="passwordForm.password.$touched && passwordForm.password.$error.minlength">
@@ -78,7 +78,8 @@
                     </div>
                     <div class="form-group">
                         <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                            ng-model="$ctrl.profile.passwordConfirm" ng-required="true" match-input="$ctrl.profile.password" ng-minlength="8"
+                            ng-model="$ctrl.profile.passwordConfirm" ng-required="true" match-input="$ctrl.profile.password"
+                            ng-minlength="8" ng-maxlength="32" maxlength="32"
                             ng-class="{'form-field-error': passwordForm.passwordConfirm.$touched && passwordForm.passwordConfirm.$invalid}">
                         <span class="error-help-text" ng-if="passwordForm.passwordConfirm.$touched && passwordForm.passwordConfirm.$error.unique">Passwords must match.</span>
                     </div>

--- a/public/js/account/settingsPage.html
+++ b/public/js/account/settingsPage.html
@@ -69,7 +69,7 @@
                 <div class="setting-edit" ng-class="{'collapsed': $ctrl.activeSetting !== 'password'}" ng-form="passwordForm">
                     <div class="form-group">
                         <input name="password" type="password" class="form-control input-lg" placeholder="Password"
-                            ng-model="$ctrl.profile.password" ng-required="true" ng-minlength="8" ng-maxlength="32" maxlength="32"
+                            ng-model="$ctrl.profile.password" ng-required="true" ng-minlength="8"
                             ng-class="{'form-field-error': passwordForm.password.$touched && passwordForm.password.$invalid}">
                         <span class="error-help-text"
                             ng-if="passwordForm.password.$touched && passwordForm.password.$error.minlength">
@@ -78,8 +78,7 @@
                     </div>
                     <div class="form-group">
                         <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                            ng-model="$ctrl.profile.passwordConfirm" ng-required="true" match-input="$ctrl.profile.password"
-                            ng-minlength="8" ng-maxlength="32" maxlength="32"
+                            ng-model="$ctrl.profile.passwordConfirm" ng-required="true" match-input="$ctrl.profile.password" ng-minlength="8"
                             ng-class="{'form-field-error': passwordForm.passwordConfirm.$touched && passwordForm.passwordConfirm.$invalid}">
                         <span class="error-help-text" ng-if="passwordForm.passwordConfirm.$touched && passwordForm.passwordConfirm.$error.unique">Passwords must match.</span>
                     </div>

--- a/public/js/account/settingsPage.html
+++ b/public/js/account/settingsPage.html
@@ -69,12 +69,16 @@
                 <div class="setting-edit" ng-class="{'collapsed': $ctrl.activeSetting !== 'password'}" ng-form="passwordForm">
                     <div class="form-group">
                         <input name="password" type="password" class="form-control input-lg" placeholder="Password"
-                            ng-model="$ctrl.profile.password" ng-required="true"
+                            ng-model="$ctrl.profile.password" ng-required="true" ng-minlength="8"
                             ng-class="{'form-field-error': passwordForm.password.$touched && passwordForm.password.$invalid}">
+                        <span class="error-help-text"
+                            ng-if="passwordForm.password.$touched && passwordForm.password.$error.minlength">
+                            Please use a password that is at least 8 characters.
+                        </span>
                     </div>
                     <div class="form-group">
                         <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                            ng-model="$ctrl.profile.passwordConfirm" ng-required="true" match-input="$ctrl.profile.password"
+                            ng-model="$ctrl.profile.passwordConfirm" ng-required="true" match-input="$ctrl.profile.password" ng-minlength="8"
                             ng-class="{'form-field-error': passwordForm.passwordConfirm.$touched && passwordForm.passwordConfirm.$invalid}">
                         <span class="error-help-text" ng-if="passwordForm.passwordConfirm.$touched && passwordForm.passwordConfirm.$error.unique">Passwords must match.</span>
                     </div>

--- a/public/js/account/signupPage.html
+++ b/public/js/account/signupPage.html
@@ -29,7 +29,7 @@
                 </div>
                 <div class="form-group">
                     <input name="password" type="password" class="form-control input-lg" placeholder="Password"
-                        ng-model="$ctrl.signupDetails.password" ng-required="true" ng-minlength="8" ng-maxlength="32" maxlength="32"
+                        ng-model="$ctrl.signupDetails.password" ng-required="true" ng-minlength="8"
                         ng-class="{'form-field-error': signupForm.password.$touched && signupForm.password.$invalid}">
                     <span class="error-help-text"
                         ng-if="signupForm.password.$touched && signupForm.password.$error.minlength">
@@ -38,8 +38,7 @@
                 </div>
                 <div class="form-group">
                     <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                        ng-model="$ctrl.signupDetails.passwordConfirm" ng-required="true" ng-minlength="8"
-                        ng-maxlength="32" maxlength="32" match-input="$ctrl.signupDetails.password"
+                        ng-model="$ctrl.signupDetails.passwordConfirm" ng-required="true" ng-minlength="8" match-input="$ctrl.signupDetails.password"
                         ng-class="{'form-field-error': signupForm.passwordConfirm.$touched && signupForm.passwordConfirm.$invalid}">
                     <span class="error-help-text" ng-if="signupForm.passwordConfirm.$touched && signupForm.passwordConfirm.$error.unique">Passwords must match.</span>
                 </div>

--- a/public/js/account/signupPage.html
+++ b/public/js/account/signupPage.html
@@ -29,7 +29,7 @@
                 </div>
                 <div class="form-group">
                     <input name="password" type="password" class="form-control input-lg" placeholder="Password"
-                        ng-model="$ctrl.signupDetails.password" ng-required="true" ng-minlength="8"
+                        ng-model="$ctrl.signupDetails.password" ng-required="true" ng-minlength="8" ng-maxlength="32" maxlength="32"
                         ng-class="{'form-field-error': signupForm.password.$touched && signupForm.password.$invalid}">
                     <span class="error-help-text"
                         ng-if="signupForm.password.$touched && signupForm.password.$error.minlength">
@@ -38,7 +38,8 @@
                 </div>
                 <div class="form-group">
                     <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                        ng-model="$ctrl.signupDetails.passwordConfirm" ng-required="true" ng-minlength="8" match-input="$ctrl.signupDetails.password"
+                        ng-model="$ctrl.signupDetails.passwordConfirm" ng-required="true" ng-minlength="8"
+                        ng-maxlength="32" maxlength="32" match-input="$ctrl.signupDetails.password"
                         ng-class="{'form-field-error': signupForm.passwordConfirm.$touched && signupForm.passwordConfirm.$invalid}">
                     <span class="error-help-text" ng-if="signupForm.passwordConfirm.$touched && signupForm.passwordConfirm.$error.unique">Passwords must match.</span>
                 </div>

--- a/public/js/account/signupPage.html
+++ b/public/js/account/signupPage.html
@@ -29,12 +29,16 @@
                 </div>
                 <div class="form-group">
                     <input name="password" type="password" class="form-control input-lg" placeholder="Password"
-                        ng-model="$ctrl.signupDetails.password" ng-required="true"
+                        ng-model="$ctrl.signupDetails.password" ng-required="true" ng-minlength="8"
                         ng-class="{'form-field-error': signupForm.password.$touched && signupForm.password.$invalid}">
+                    <span class="error-help-text"
+                        ng-if="signupForm.password.$touched && signupForm.password.$error.minlength">
+                        Please use a password that is at least 8 characters.
+                    </span>
                 </div>
                 <div class="form-group">
                     <input name="passwordConfirm" type="password" class="form-control input-lg" placeholder="Retype password"
-                        ng-model="$ctrl.signupDetails.passwordConfirm" ng-required="true" match-input="$ctrl.signupDetails.password"
+                        ng-model="$ctrl.signupDetails.passwordConfirm" ng-required="true" ng-minlength="8" match-input="$ctrl.signupDetails.password"
                         ng-class="{'form-field-error': signupForm.passwordConfirm.$touched && signupForm.passwordConfirm.$invalid}">
                     <span class="error-help-text" ng-if="signupForm.passwordConfirm.$touched && signupForm.passwordConfirm.$error.unique">Passwords must match.</span>
                 </div>


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #253

# Motivation and context
It's good to enforce minimum password lengths to make bruteforcing more difficult.

# Screenshots
| before | after |
|---|---|
| ![before](https://user-images.githubusercontent.com/5104274/61417138-09468000-a8ab-11e9-963f-0bc95d2eab88.png) | ![after](https://user-images.githubusercontent.com/5104274/61417149-13687e80-a8ab-11e9-8d08-871f21a54039.png) |

# What I did
- added ng-minlength directive to password fields with length 8
- added server-side checks to ensure passwords are the correct length before saving them. Won't save password if it's too short
- added error message "Please use a password that is at least 8 characters." if user tries to use a short password
