### PR TITLE
[#282] campaign title covers buttons in mobile view

### DIFF
--- a/public/js/home/campaigns-list.html
+++ b/public/js/home/campaigns-list.html
@@ -3,19 +3,19 @@
     <br><br>
     <div ng-repeat="campaign in $ctrl.campaigns" class="background-white">
         <div class="campaign-info">
-            <div class="title">
-                <h4 class="campaign-title">{[{campaign.title}]}</h4>
-                <h5 ng-if="!campaign.publish">DRAFT</h5>
-            </div>
             <div class="content">
+                <div class="title">
+                    <h4 class="campaign-title">{[{campaign.title}]}</h4>
+                    <h5 ng-if="!campaign.publish">DRAFT</h5>
+                </div>
                 <div class="text-center">
                     <div class="option-button-container">
                         <!-- TODO: This should give feedback, ideally like in the mockup -->
-                        <div class="option-button">
+                        <a><div class="option-button">
                             <input type="image" src="/images/white_link_icon.jpg" ngclipboard data-clipboard-text="{[{$ctrl.hostName}]}{[{campaign.url}]}" ng-click="$ctrl.toggleClipboardText(campaign.id)" />
                             <p>Link</p>
                             <p ng-class="showClipboardText[campaign.id] ? 'clipboardTextAnimation clipboardText' : 'clipboardText'">Copied to clipboard!</p>
-                        </div>
+                        </div></a>
                         <a ng-href="{[{campaign.url}]}/edit"><div class="option-button">
                             <input type="image" src="/images/pencil.jpg" />
                             <p>Edit</p>
@@ -34,13 +34,12 @@
                         </div>
                     </div>
                 </div>
+                <div class="date">
+                    <small class="date">Created: {[{campaign.createdAt | date: 'MMM d, yyyy'}]}</small>
+                </div>
             </div>
-            <div class="date">
-                <small class="date">Created: {[{campaign.createdAt | date: 'MMM d, yyyy'}]}</small>
-            </div>
-            <label>
-                <input type="checkbox" class="toggleAnalytics"/>
-                <div class="analytics">
+                <input type="checkbox" class="toggleAnalytics" id="toggleAnalytics{[{campaign.id}]}" name="toggleAnalytics{[{campaign.id}]}"/>
+                <label class="analytics" for="toggleAnalytics{[{campaign.id}]}">
                     <div class="analytics-container">
                         <p class="analytics-number">{[{campaign.analytics.call}]}</p>
                         <p>Calls</p>
@@ -49,8 +48,7 @@
                         <p class="analytics-number">{[{campaign.analytics.visit}]}</p>
                         <p>Visits</p>
                     </div>
-                </div>
-            </label>
+                </label>
         </div>
     </div>
 </div>

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -1,23 +1,17 @@
 .campaign-list .campaign-info {
     background-color: $white;
-    padding: 0;
     margin: 10px auto;
     color: $blue-light;
     font-weight: bold;
     border: 1px solid $blue-light;
     display: flex;
-    flex-flow: column wrap;
     justify-content: space-between;
-    height: 252px;
+    align-items: stretch;
     position: relative;
 
-    .title {
-        height: 75px;
-
-        h4 {
-            font-size: 1.6em;
-            font-weight: bold;
-        }
+    .title h4 {
+        font-size: 1.6em;
+        font-weight: bold;
     }
 
     .date {
@@ -30,21 +24,18 @@
     .toggleAnalytics {
         display: none;
     }
+
     .analytics {
         background: $blue-light;
         color: white;
-        flex-basis: 100%;
-        padding: 20px 0px;
+        margin: 0px;
         display: flex;
         flex-flow: column nowrap;
-        justify-content: space-around;
+        justify-content: center;
         align-items: center;
-        height: 250px;
-        width: 150px;
-        order: 100;
 
         .analytics-container {
-            padding: 10px 0px;
+            padding: 10px;
             font-size: 0.75em;
             .analytics-number {
                 font-size: 1.2em;
@@ -52,28 +43,21 @@
         }
     }
     .content {
-        flex-grow: 3;
-        display: flex;
-        flex-flow: column nowrap;
-        align-items: center;
-        justify-content: space-evenly;
-        height: 125px;
-        width: calc(100% - 150px);
+        flex-grow: 1;
 
         .analytics-display {
             font-size: 1.2em;
         }
 
         .campaign-date {
-            display: inline-block;
             border-bottom: 1px solid $blue-light;
-            padding-bottom: 6px;
         }
 
         .option-button-container {
             display: flex;
+            justify-content: center;
+            align-items: center;
         }
-
         .option-button {
             display: inline-block;
             width: 4em;
@@ -95,31 +79,30 @@
 
     @media (max-width: $tablet-min) {
         flex-flow: column nowrap;
-        height: auto;
+
         .date {
-            height: auto;
-            order: 3;
-            margin-bottom: 2em;
+            margin-bottom: 1em;
         }
+
         .analytics {
-            flex-flow: row nowrap;
             border-left: 0;
             padding: 10px 20px;
-            order: 4;
-            width: auto;
             height: 10px;
             overflow: hidden;
-            flex-basis: unset;
-            align-items: flex-end;
             position: absolute;
             bottom: 0;
             left: 0;
             right: 0;
             transition: height 0.5s;
+            flex-flow: row nowrap;
+            justify-content: space-evenly;
+
+            .analytics-container {
+                opacity: 0;
+                transition: opacity 0.5s;
+            }
         }
-        .toggleAnalytics:checked + .analytics {
-            height: calc(100% - 75px);
-        }
+
         .analytics::after {
             content: "analytics";
             font-size: 0.5em;
@@ -132,9 +115,7 @@
             margin: 0.2em;
             transition: 0.25s;
         }
-        .toggleAnalytics:checked + .analytics::after {
-            opacity: 0;
-        }
+
         .analytics::before {
             content: "";
             position: absolute;
@@ -148,12 +129,23 @@
             transform: rotate(-45deg);
             transition: 0.25s;
         }
-        .toggleAnalytics:checked + .analytics::before {
-            transform: rotate(135deg);
-        }
-        .content {
-            height: auto;
-            width: auto;
+        
+        .toggleAnalytics:checked {
+            + .analytics {
+                height: 140px;
+
+                .analytics-container {
+                    opacity: 1;
+                }
+            }
+
+            + .analytics::after {
+                opacity: 0;
+            }
+
+            + .analytics::before {
+                transform: rotate(135deg);
+            }
         }
     }
 

--- a/public/scss/campaigns.scss
+++ b/public/scss/campaigns.scss
@@ -43,6 +43,7 @@
         }
     }
     .content {
+        padding: 0 10px;
         flex-grow: 1;
 
         .analytics-display {


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #282

# Motivation and context
my previous PR #259 introduced an overflow bug in mobile when the titles are long
My flexbox magic was unnecessarily complicated, so I made it simpler and allowed the title to grow without overflowing over the next elements.

# Screenshots
| | before | after |
|--|---|---|
| mobile | <img width="375" alt="Screen Shot 2019-07-31 at 11 07 36 AM" src="https://user-images.githubusercontent.com/17886804/62236214-749c5180-b383-11e9-9b09-2991d2740aef.png"> | ![untitled1](https://user-images.githubusercontent.com/17886804/62236025-12435100-b383-11e9-9a72-be269ab67d15.gif) |
| desktop | <img width="845" alt="Screen Shot 2019-07-31 at 11 07 47 AM" src="https://user-images.githubusercontent.com/17886804/62236221-7c5bf600-b383-11e9-9aed-3e7733a7ba8b.png"> | <img width="1221" alt="Screen Shot 2019-08-03 at 12 05 09 AM" src="https://user-images.githubusercontent.com/17886804/62408776-bfd08300-b582-11e9-8e4e-aa55698c59d8.png"> |
