### PR TITLE
[#287] Google Places Autocomplete Filter

### DIFF
--- a/public/js/campaign/visitor.controller.js
+++ b/public/js/campaign/visitor.controller.js
@@ -7,7 +7,6 @@ export default angular.module('helloGov')
         $scope.campaign = new URL($location.absUrl()).pathname.replace(/[/]/g, '');
         $scope.locResult = '';
         $scope.locOptions = {
-            types: 'establishment', // this will filter most (but not) all incomplete addresses
             watchEnter: true        // pressing enter will autofill the most relevant autocomplete result
         };
         $scope.locDetails = '';


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
Resolves #287 

# Motivation and context

> Autofill is not working on all addresses, whoever has time to look at this bug
> 
> ex: https://www.hellogov.app/O34QJGN5I

Before
<img width="625" alt="Screen Shot 2019-08-05 at 8 52 15 PM" src="https://user-images.githubusercontent.com/8117210/62510202-fdbbea00-b7c2-11e9-97a9-709f97c9e5a7.png">

After
<img width="844" alt="Screen Shot 2019-08-05 at 8 52 24 PM" src="https://user-images.githubusercontent.com/8117210/62510207-044a6180-b7c3-11e9-97d4-5c21d030dfa9.png">


# What I did
* Remove validation for public establishments in Google places Autocomplete request:
https://developers.google.com/places/web-service/autocomplete
