### PR TITLE
add node version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
     "eslint-plugin-standard": "^2.1.1",
     "nodemon": "^1.18.7",
     "webpack-dev-middleware": "^1.10.1"
+  },
+  "engines": {
+    "node": "10.15.0"
   }
 }


### PR DESCRIPTION
# Motivation and context
for some reason heroku needed the node version specified all of a sudden? ok

# What I did
- added the node version in package.json