### PR TITLE
[#323] Make the email field have a lowercase type to make it case insensitive

### DIFF
--- a/app/models/signup.js
+++ b/app/models/signup.js
@@ -3,7 +3,7 @@ var shortid = require('shortid');
 var Schema = mongoose.Schema;
 
 var Signup = new Schema({
-    email: { type: String, trim: true },
+    email: { type: String, lowercase: true, trim: true },
     signupLink: { type: String, trim: true, 'default': shortid.generate }
 }, {
     timestamps: {


### PR DESCRIPTION
resolves #323 

# Motivation and context
Email was case sensitive and the error was confusing if the user used a different capitalization as the admin had entered for their email. 

# What I did
Pretty much what it says in the title. Signups w/ capital letters that are pending when this gets merged in will be left in stuck state. If there are signups in this state, we'd have to delete/fix those in the DB directly since there's isn't an API.

Inspired by: https://stackoverflow.com/a/13991704
